### PR TITLE
테스트-실행 분리 제안

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import threading
 import unittest
+import argparse
+import sys
 
 from car import Car
 from car_controller import CarController
@@ -503,21 +505,26 @@ def file_input_thread(gui):
 # 메인 실행
 # -> 가급적 main login은 수정하지 마세요.
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test", action="store_true", help="Run in test mode")
+    args = parser.parse_args()
+
     car = Car()
     car_controller = CarController(car)
 
-    # GUI는 메인 스레드에서 실행
-    gui = CarSimulatorGUI(car_controller,
-                          lambda command: execute_command_callback(command,
-                                                                   car_controller))
+    if args.test:
+        unittest.main(argv=[sys.argv[0]])
 
-    # 파일 입력 스레드는 별도로 실행하여, GUI와 병행 처리
-    input_thread = threading.Thread(target=file_input_thread, args=(gui,))
-    input_thread.daemon = True  # 메인 스레드가 종료되면 서브 스레드도 종료되도록 설정
-    input_thread.start()
+    else:
+        # GUI는 메인 스레드에서 실행
+        gui = CarSimulatorGUI(car_controller,
+                              lambda command: execute_command_callback(command,
+                                                                       car_controller))
 
-    # GUI 시작 (메인 스레드에서 실행)
-    gui.start()
+        # 파일 입력 스레드는 별도로 실행하여, GUI와 병행 처리
+        input_thread = threading.Thread(target=file_input_thread, args=(gui,))
+        input_thread.daemon = True  # 메인 스레드가 종료되면 서브 스레드도 종료되도록 설정
+        input_thread.start()
 
-    # 테스트 실행
-    unittest.main()
+        # GUI 시작 (메인 스레드에서 실행)
+        gui.start()

--- a/main.py
+++ b/main.py
@@ -478,12 +478,12 @@ def can_operate_trunk(car_controller, trunk_status):
 
 def trunk_open_condition_check(car_controller):
     if can_operate_trunk(car_controller, trunk_status=True):
-        car_controller.car.open_trunk()
+        car_controller.open_trunk()
 
 
 def trunk_close_condition_check(car_controller):
     if can_operate_trunk(car_controller, trunk_status=False):
-        car_controller.car.close_trunk()
+        car_controller.close_trunk()
 
 
 # 파일 경로를 입력받는 함수


### PR DESCRIPTION
## 🔎 작업 내용

1. 테스트-일반적 실행 분리
이전에는 코드 실행 시 유닛 테스트와 GUI가 같이 실행되었지만, 이제 테스트와 GUI실행 중 하나를 선택할 수 있습니다. 

명령창에
```powershell
# Windows
py .\main.py 
```
또는
```bash
# mac, linux
python3 main.py
```
입력 시 정상적으로 GUI실행이 되며(VSCode에서는 실행 버튼 누르시면 됩니다.)

테스트 시에는
```powershell
# Windows
py .\main.py --test
```
또는
```bash
# mac, linux
python3 main.py --test
```
입력 시 테스트만 실행됩니다.
성적 반영 사항은 아니지만, 테스트 실행 편의성 때문에 구현한 거라 의견을 묻고 싶습니다.


2. 트렁크 개방 함수 작은 수정
```python
car_controller.car.open_trunk()
```
이 부분을
```python
car_controller.open_trunk()
```
이렇게 수정했습니다.(중요합니다)